### PR TITLE
Overhaul syntax and folding

### DIFF
--- a/ftplugin/shellspec.vim
+++ b/ftplugin/shellspec.vim
@@ -1,14 +1,1 @@
-setlocal syntax=shellspec.sh
-
-function! ShellspecFolds()
-    let thisline = getline(v:lnum)
-    if match(thisline, '^\s*\(Describe\|ExampleGroup\|Context\|Mock\|It\)') >= 0
-        return "a1"
-    elseif match(thisline, '^\s*\(End\)') >= 0
-        return "s1"
-    else
-        return "="
-    endif
-endfunction
-setlocal foldmethod=expr
-setlocal foldexpr=ShellspecFolds()
+setlocal foldmethod=syntax

--- a/syntax/shellspec.vim
+++ b/syntax/shellspec.vim
@@ -1,33 +1,91 @@
-syntax keyword shellSpecKeyWords End
-syntax keyword shellSpecKeyWords ExampleGroup Describe Context
-syntax keyword shellSpecKeyWords Example It Specify
-syntax keyword shellSpecKeyWords After AfterEach
-syntax keyword shellSpecKeyWords Mock The Data Parameters
-syntax keyword shellSpecKeyWords When nextgroup=shellSpecKeyWords2
-syntax keyword shellSpecKeyWords2 call run nextgroup=shellSpecKeyWords3
-syntax keyword shellSpecKeyWords3 command script source
+" Use shell syntax mixed with shellspec one, both on top level and contained
+runtime! syntax/sh.vim
+unlet b:current_syntax
+syntax include @Shell syntax/sh.vim
 
-syntax keyword shellSpecSubjects stdout output line word stderr error status path file directory value function variable
+" Objects that can be used (almost) in every place in the spec file
+syntax cluster shellSpecEverywhere contains=@Shell,@shellSpecHelpers,shellSpecHooksRegion,shellSpecDirectives
 
-syntax keyword shellSpecModifiers line lines word length contents result
-syntax keyword shellSpecModifiers of should equal eq include
-syntax keyword shellSpecModifiers start end be match nextgroup=shellSpecModifiers2
-syntax keyword shellSpecModifiers2 pattern with defined undefined present blank exported readonly valid nextgroup=shellSpecModifiers3
-syntax keyword shellSpecModifiers3 number funcname
+""" Examples grouping {{{1
+syntax region shellSpecExampleGroupRegion matchgroup=shellSpecExampleGroup start="\<[fx]\?\(ExampleGroup\|Describe\|Context\)\>" end="End" fold contains=@shellSpecEverywhere,shellSpecExampleGroupRegion,shellSpecExampleRegion
+syntax region shellSpecExampleRegion matchgroup=shellSpecExample start="\<[fx]\?\(Example\|It\|Specify\)\>" end="End" fold contains=@shellSpecEverywhere,shellSpecEvaluationStart,shellSpecExpectationStart
 
-syntax keyword shellSpecMatchers satisfy exist be exist file directory empty empty symlink pipe socket readable writable executable block_device character_device has have setgid setgid setuid setuid
 
-syntax keyword shellSpecHooks Before BeforeEach After AfterEach BeforeAll AfterAll BeforeCall AfterCall BeforeRun AfterRun
+""" Helpers {{{1
+syntax cluster shellSpecHelpers contains=shellSpecHelpersComplexRegion,shellSpecHelpersSimple
+syntax region shellSpecHelpersComplexRegion matchgroup=shellSpecHelpersComplex start="^\s*\(Mock\s\+.*\|Data\(:raw\|:expand\)\?\(\s\+|.*\)\?\|Parameters\(:block\|:matrix\|:dynamic\)\?\)\s*$" end="End" fold contains=@shellSpecEverywhere
+syntax match shellSpecHelpersSimple "\(Skip\(\s\+if\)\?\|Pending\|Todo\|Data\|Parameters:value\|Include\|Path\|File\|Dir\|Intercept\|Set\|Dump\)"
 
-syntax match shellSpecDirectives "[%]\(const\|text\|putsn\|=\|-\|puts\|logger\|preserve\)" containedin=ALL
 
-hi def link shellSpecKeyWords Function
-hi def link shellSpecKeyWords2 Statement
-hi def link shellSpecKeyWords3 Statement
-hi def link shellSpecSubjects Identifier
+""" Evaluation {{{1
+syntax keyword shellSpecEvaluationStart When nextgroup=shellSpecEvaluation2 skipwhite contained
+syntax keyword shellSpecEvaluation2 call run nextgroup=shellSpecEvaluation3 skipwhite contained
+syntax keyword shellSpecEvaluation3 command script source contained
+
+
+""" Expectation {{{1
+syntax cluster shellSpecAllModifiersAndSubjects contains=shellSpecModifiersOrdinals,shellSpecModifiersShorthand,shellSpecModifiers,@shellSpecSubjects
+syntax cluster shellSpecSubjects contains=shellSpecSimpleSubjects,shellSpecComplexSubjects
+syntax cluster shellSpecMatchers contains=shellSpecSimpleMatchers,shellSpecBeMatchers,shellSpecHasMathers
+
+syntax keyword shellSpecExpectationStart The Assert nextgroup=@shellSpecAllModifiersAndSubjects skipwhite contained
+
+syntax keyword shellSpecModifiersOrdinals zeroth first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth sixteenth seventeenth eighteenth nineteenth twentieth nextgroup=shellSpecModifiersShorthand,shellSpecModifiers skipwhite contained
+
+" Shorthand -> both as modifiers and subjects
+syntax keyword shellSpecModifiersShorthand line word nextgroup=shellSpecModifiersShorthandFiller skipwhite contained
+syntax match shellSpecModifiersShorthandFiller "\zs.\{-}\ze\(of\|should\)" nextgroup=shellSpecModifiersOf,shellSpecExpectationShould skipwhite contained transparent
+syntax keyword shellSpecModifiers lines length contents result nextgroup=shellSpecModifiersFiller skipwhite contained
+syntax match shellSpecModifiersFiller "\zs.\{-}\zeof" nextgroup=shellSpecModifiersOf skipwhite contained transparent
+syntax keyword shellSpecModifiersOf of nextgroup=@shellSpecAllModifiersAndSubjects skipwhite contained
+
+syntax keyword shellSpecSimpleSubjects stdout output stderr error status nextgroup=shellSpecExpectationShould skipwhite contained
+syntax keyword shellSpecComplexSubjects path file directory function value variable nextgroup=shellSpecSubjectsFiller skipwhite contained
+syntax match shellSpecSubjectsFiller "\zs.*\zeshould" nextgroup=shellSpecExpectationShould skipwhite contained transparent
+
+syntax match shellSpecExpectationShould "should\(\s\+not\)\?\>" nextgroup=@shellSpecMatchers skipwhite contained
+
+syntax match shellSpecSimpleMatchers "\(satisfy\|exist\|equal\|eq\|start\s\+with\|end\s\+with\|include\|match\s\+pattern\)\>" contained
+syntax match shellSpecBeMatchers "be\s\+\(exist\|file\|directory\|empty\s\+file\|empty\s\+directory\|symlink\|pipe\|socket\|readable\|writable\|executable\|block_device\|character_device\|success\|failure\|successful\|valid\s\+number\|valid\s\+funcname\|defined\|undefined\|present\|blank\|exported\|readonly\)\>" contained
+syntax match shellSpecHasMathers "\(has\|have\)\s\+\(setgid\|setuid\)\>" contained
+
+
+""" Hooks {{{1
+syntax region shellSpecHooksRegion matchgroup=shellSpecHooks start="\(Before\|BeforeEach\|After\|AfterEach\|BeforeAll\|AfterAll\|BeforeCall\|AfterCall\|BeforeRun\|AfterRun\)\s*['"]" end="['"]" fold contains=@Shell
+
+""" Directives {{{1
+syntax match shellSpecDirectives "%\(const\|text\|putsn\|=\|-\|puts\|printf\|sleep\|preserve\|logger\|data\)\>" containedin=@Shell
+
+
+""" Highlighting {{{1
+hi def link shellSpecExampleGroup ModeMsg
+hi def link shellSpecExample shellSpecExampleGroup
+
+hi def link shellSpecHelpersComplex Special
+hi def link shellSpecHelpersSimple shellSpecHelpersComplex
+
+hi def link shellSpecEvaluationStart Function
+
+hi def link shellSpecEvaluation2 Statement
+hi def link shellSpecEvaluation3 shellSpecEvaluation2
+
+hi def link shellSpecExpectationStart Question
+hi def link shellSpecExpectationShould shellSpecExpectationStart
+
+hi def link shellSpecSimpleSubjects Identifier
+hi def link shellSpecComplexSubjects shellSpecSimpleSubjects
+
 hi def link shellSpecModifiers Operator
-hi def link shellSpecModifiers2 Operator
-hi def link shellSpecModifiers3 Operator
-hi def link shellSpecMatchers Conditional
+hi def link shellSpecModifiersOrdinals shellSpecModifiers
+hi def link shellSpecModifiersShorthand shellSpecModifiers
+hi def link shellSpecModifiersOf shellSpecModifiers
+
+hi def link shellSpecSimpleMatchers Conditional
+hi def link shellSpecBeMatchers shellSpecSimpleMatchers
+hi def link shellSpecHasMathers shellSpecSimpleMatchers
+
 hi def link shellSpecHooks Label
+
 hi def link shellSpecDirectives Macro
+
+" {{{1 vim: fdm=marker

--- a/syntax/shellspec.vim
+++ b/syntax/shellspec.vim
@@ -64,9 +64,8 @@ hi def link shellSpecExample shellSpecExampleGroup
 hi def link shellSpecHelpersComplex Special
 hi def link shellSpecHelpersSimple shellSpecHelpersComplex
 
-hi def link shellSpecEvaluationStart Function
-
-hi def link shellSpecEvaluation2 Statement
+hi def link shellSpecEvaluationStart Question
+hi def link shellSpecEvaluation2 shellSpecEvaluationStart
 hi def link shellSpecEvaluation3 shellSpecEvaluation2
 
 hi def link shellSpecExpectationStart Question
@@ -75,7 +74,7 @@ hi def link shellSpecExpectationShould shellSpecExpectationStart
 hi def link shellSpecSimpleSubjects Identifier
 hi def link shellSpecComplexSubjects shellSpecSimpleSubjects
 
-hi def link shellSpecModifiers Operator
+hi def link shellSpecModifiers shellSpecSimpleSubjects
 hi def link shellSpecModifiersOrdinals shellSpecModifiers
 hi def link shellSpecModifiersShorthand shellSpecModifiers
 hi def link shellSpecModifiersOf shellSpecModifiers


### PR DESCRIPTION
Again see commit messages

With a test file that I somehow cannot attach to this MR, so I just paste it:
```
if something ; then echo "something" ; fi
Describe "shellspec.vim"
  if something ; then
    echo "something"
  fi
  function()
  {
    if something ; then
      something
    fi
  }

  BeforeAll '{
    cp something something.txt
    rm -f something
  }'
  AfterEach 'rm -f *.root'

  ExampleGroup "a group"
    Parameters:value h cc

    Skip if something
    It "does something interesting"
      Data "class A { public: something"
      Parameters:dynamic
        for i in 1 2 3; do
          %data "#$i" 1 2 3
        done
      End
      Data
        #|#define MySuperMacro \
        #|DoYetOtherSuperThing()
      End
      result() { %text
        #|class A {
        #|  something
      }

      When run something
      When run script something
      When call command something
      The status should be success
      The output should not be present
      The output should eq "$(result)"
      The status should have setgid
      The error should include "Usage:"
      The file "file_name" should exist
      The line 1 should equal
      The lines of stdout should equal 5
      The line 2 of output should equal 4
      The word 1 of line 2 of output should equal 4
      The first word of second line of output should equal 4
    End
  End
End
```

the old syntax gives a broken highlight due to `Skip if`:

![old_broken_by_SkipIf](https://github.com/user-attachments/assets/fa9bf7e5-9bf0-4324-ae92-0a35d1a70bc3)

while without it:

![old_syntax](https://github.com/user-attachments/assets/0ba8a499-9722-40e0-b637-f1a0c0d90c37)

The new one with with different elements emphasised with different colors:

![new_syntax](https://github.com/user-attachments/assets/15a3dd59-66de-482d-8037-b53c45f89334)


And finally with less cluttered highlighting:

![new_better](https://github.com/user-attachments/assets/785a8368-4064-4ff6-b455-fd9ccc02f330)

